### PR TITLE
Styling fixes

### DIFF
--- a/pkg/web/ui/components/quote_display.templ
+++ b/pkg/web/ui/components/quote_display.templ
@@ -21,7 +21,7 @@ templ quoteContent(props QuoteDisplayProps) {
 		<div class="size-8 shrink-0">
 			@QuotationMark()
 		</div>
-		<div class="max-h-full overflow-y-auto whitespace-pre-wrap text-left">
+		<div class="max-h-full overflow-y-auto text-left">
 			@templ.Raw(props.Content)
 		</div>
 	</div>
@@ -37,7 +37,7 @@ templ QuoteDisplay(props QuoteDisplayProps) {
 				hx-trigger={ "click, keyup[key=='" + props.KeyboardKey + "'] from:body" }
 				hx-post="/rank"
 				hx-target="#rank-form"
-				class="max-h-full w-full flex-grow transition-all"
+				class="max-h-full w-full flex-grow transition-all [&_p]:whitespace-pre-wrap"
 				type="submit"
 				name="winner"
 				value={ props.ID }

--- a/pkg/web/ui/components/quote_display_templ.go
+++ b/pkg/web/ui/components/quote_display_templ.go
@@ -94,7 +94,7 @@ func quoteContent(props QuoteDisplayProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div><div class=\"max-h-full overflow-y-auto whitespace-pre-wrap text-left\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div><div class=\"max-h-full overflow-y-auto text-left\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -197,7 +197,7 @@ func QuoteDisplay(props QuoteDisplayProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\" hx-post=\"/rank\" hx-target=\"#rank-form\" class=\"max-h-full w-full flex-grow transition-all\" type=\"submit\" name=\"winner\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\" hx-post=\"/rank\" hx-target=\"#rank-form\" class=\"max-h-full w-full flex-grow transition-all [&_p]:whitespace-pre-wrap\" type=\"submit\" name=\"winner\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/pkg/web/ui/components/rank_result.templ
+++ b/pkg/web/ui/components/rank_result.templ
@@ -29,7 +29,7 @@ templ RankResult(props RankResultProps) {
 	{{ quoteARankChange := props.QuoteARankBefore - props.QuoteARankAfter }}
 	{{ quoteBRankChange := props.QuoteBRankBefore - props.QuoteBRankAfter }}
 
-	<div id="rank-results" class="w-full rounded bg-zinc-700 p-2 [&_p]:inline" hx-swap-oob="true">
+	<div id="rank-results" class="w-full rounded-lg bg-zinc-700 p-2 [&_p]:inline" hx-swap-oob="true">
 		<div class="mb-0.5 text-sm">
 			<span class="mr-1">@formatRankDisplay(props.QuoteARankAfter, quoteARankChange)</span>
 			<span class="prose prose-sm inline max-w-none">@templ.Raw(props.QuoteAContent)</span>

--- a/pkg/web/ui/components/rank_result_templ.go
+++ b/pkg/web/ui/components/rank_result_templ.go
@@ -152,7 +152,7 @@ func RankResult(props RankResultProps) templ.Component {
 		ctx = templ.ClearChildren(ctx)
 		quoteARankChange := props.QuoteARankBefore - props.QuoteARankAfter
 		quoteBRankChange := props.QuoteBRankBefore - props.QuoteBRankAfter
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"rank-results\" class=\"w-full rounded bg-zinc-700 p-2 [&_p]:inline\" hx-swap-oob=\"true\"><div class=\"mb-0.5 text-sm\"><span class=\"mr-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"rank-results\" class=\"w-full rounded-lg bg-zinc-700 p-2 [&_p]:inline\" hx-swap-oob=\"true\"><div class=\"mb-0.5 text-sm\"><span class=\"mr-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
Two fixes:

1. Make the border radius for the results display match the border radius for the buttons.
2. Removes the unnecessary empty line at the end of every quote